### PR TITLE
Sort events by date

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-database:16.0.5'
 
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'com.google.android.gms:play-services-maps:16.0.0'
+    implementation 'com.google.android.gms:play-services-maps:16.1.0'
 
     implementation 'com.google.android.material:material:1.1.0-alpha02'
     implementation 'io.github.yavski:fab-speed-dial:1.0.6'
@@ -54,7 +54,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.8.0'
     annotationProcessor 'androidx.annotation:annotation:1.0.1'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.8.0'
-    implementation 'com.google.android.gms:play-services-maps:16.0.0'
+    implementation 'com.google.android.gms:play-services-maps:16.1.0'
     implementation 'com.google.android.gms:play-services-places:16.0.0'
     implementation 'com.nex3z:notification-badge:0.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'

--- a/app/src/main/java/com/huji/foodtricks/buddies/EventsTabsActivity.java
+++ b/app/src/main/java/com/huji/foodtricks/buddies/EventsTabsActivity.java
@@ -91,8 +91,8 @@ public class EventsTabsActivity extends AppCompatActivity implements TabLayout.O
                         currentUser.getChangedEvents().size() == 0) {
                     return;
                 }
-                ArrayList<String> newEvents = currentUser.getChangedEvents();
-                for (final String eventId : newEvents) {
+                ArrayList<String> updatedEvents = currentUser.getChangedEvents();
+                for (final String eventId : updatedEvents) {
                     streamer.fetchEventModelById(eventId, new EventFetchingCompletion() {
                         @Override
                         public void onFetchSuccess(EventModel model) {
@@ -197,7 +197,11 @@ public class EventsTabsActivity extends AppCompatActivity implements TabLayout.O
     public void reduceCount(int amount) {
         this.count -= amount;
         this.nBadge.setNumber(this.count);
+    }
 
+    public void resetCount() {
+        this.count = 0;
+        this.nBadge.setNumber(this.count);
     }
 
 

--- a/app/src/main/java/com/huji/foodtricks/buddies/Models/UserModel.java
+++ b/app/src/main/java/com/huji/foodtricks/buddies/Models/UserModel.java
@@ -121,6 +121,9 @@ public class UserModel implements Serializable {
         if (this.changedEvents == null) {
             this.changedEvents = new ArrayList<>();
         }
+        if (this.changedEvents.contains(changes)) {
+            return;
+        }
         this.changedEvents.add(changes);
     }
 

--- a/app/src/main/java/com/huji/foodtricks/buddies/PastEventsTabFragment.java
+++ b/app/src/main/java/com/huji/foodtricks/buddies/PastEventsTabFragment.java
@@ -30,7 +30,7 @@ public class PastEventsTabFragment extends Fragment {
 
         past_events.putAll((HashMap<String, EventModel>) getArguments().getSerializable("events"));
         this.view = (ListView) rootView.findViewById(R.id.list_view_past);
-        this.adapter = new EventListAdaptor(this.getActivity(), past_events);
+        this.adapter = new EventListAdaptor(this.getActivity(), past_events, true);
         this.view.setAdapter(adapter);
         final SwipeRefreshLayout pullToRefresh = rootView.findViewById(R.id.swipe_refresh_past);
         pullToRefresh.setOnRefreshListener(() -> {

--- a/app/src/main/java/com/huji/foodtricks/buddies/PastEventsTabFragment.java
+++ b/app/src/main/java/com/huji/foodtricks/buddies/PastEventsTabFragment.java
@@ -44,7 +44,7 @@ public class PastEventsTabFragment extends Fragment {
 
     private void updateEvents() {
         EventsTabsActivity currentActivity = (EventsTabsActivity) getActivity();
-        currentActivity.reduceCount(this.new_events.size() + this.events_to_delete.size());
+        currentActivity.resetCount();
         this.adapter.addItems(this.new_events);
         this.past_events.putAll(new_events);
         this.new_events.clear();
@@ -56,6 +56,13 @@ public class PastEventsTabFragment extends Fragment {
 
     void addEvents(String id, EventModel event) {
         this.new_events.put(id, event);
+    }
+
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+        updateEvents();
     }
 
     public void removeEvent(String id) {

--- a/app/src/main/java/com/huji/foodtricks/buddies/PlanningEventsTabFragment.java
+++ b/app/src/main/java/com/huji/foodtricks/buddies/PlanningEventsTabFragment.java
@@ -45,7 +45,7 @@ public class PlanningEventsTabFragment extends Fragment {
 
     private void updateEvents() {
         EventsTabsActivity currentActivity = (EventsTabsActivity) getActivity();
-        currentActivity.reduceCount(this.new_events.size() + this.events_to_delete.size());
+        currentActivity.resetCount();
         this.adapter.addItems(this.new_events);
         this.pending_events.putAll(new_events);
         this.new_events.clear();
@@ -54,6 +54,12 @@ public class PlanningEventsTabFragment extends Fragment {
         this.adapter.notifyDataSetChanged();
     }
 
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+        updateEvents();
+    }
 
     void addEvents(String id, EventModel event) {
         this.new_events.put(id, event);

--- a/app/src/main/java/com/huji/foodtricks/buddies/PlanningEventsTabFragment.java
+++ b/app/src/main/java/com/huji/foodtricks/buddies/PlanningEventsTabFragment.java
@@ -31,7 +31,7 @@ public class PlanningEventsTabFragment extends Fragment {
 
         pending_events.putAll((HashMap<String, EventModel>) getArguments().getSerializable("events"));
         this.view = rootView.findViewById(R.id.list_view_planning);
-        this.adapter = new EventListAdaptor(this.getActivity(), pending_events);
+        this.adapter = new EventListAdaptor(this.getActivity(), pending_events, false);
         this.view.setAdapter(adapter);
         final SwipeRefreshLayout pullToRefresh = rootView.findViewById(R.id.swipe_refresh_planning);
         pullToRefresh.setOnRefreshListener(() -> {

--- a/app/src/main/java/com/huji/foodtricks/buddies/UpcomingEventsTabFragment.java
+++ b/app/src/main/java/com/huji/foodtricks/buddies/UpcomingEventsTabFragment.java
@@ -36,7 +36,7 @@ public class UpcomingEventsTabFragment extends Fragment {
 
         future_events.putAll((HashMap<String, EventModel>) getArguments().getSerializable("events"));
         ListView lv = rootView.findViewById(R.id.list_view_upcoming);
-        this.adapter = new EventListAdaptor(this.getActivity(), future_events);
+        this.adapter = new EventListAdaptor(this.getActivity(), future_events, false);
         lv.setAdapter(adapter);
         final SwipeRefreshLayout pullToRefresh = rootView.findViewById(R.id.swipe_refresh_future);
         pullToRefresh.setOnRefreshListener(() -> {

--- a/app/src/main/java/com/huji/foodtricks/buddies/UpcomingEventsTabFragment.java
+++ b/app/src/main/java/com/huji/foodtricks/buddies/UpcomingEventsTabFragment.java
@@ -50,13 +50,20 @@ public class UpcomingEventsTabFragment extends Fragment {
 
     private void updateEvents() {
         EventsTabsActivity currentActivity = (EventsTabsActivity) getActivity();
-        currentActivity.reduceCount(this.new_events.size() + this.events_to_delete.size());
+        currentActivity.resetCount();
         this.adapter.addItems(this.new_events);
         this.future_events.putAll(new_events);
         this.new_events.clear();
         this.adapter.removeItems(this.events_to_delete);
         this.events_to_delete.clear();
         this.adapter.notifyDataSetChanged();
+    }
+
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+        updateEvents();
     }
 
     public void addEvents(String id, EventModel event) {


### PR DESCRIPTION
Added sorting of events in each tab by their date.
Currently only sorts in tab creation, and newly added events are added at the top (because I guess it's more natural that new stuff show up at the top, even if they're events it the farther future).

Something that I noticed: right now a user can create an event in the past. We'll probably want to disable that option..